### PR TITLE
Allow the bumpversion workflow to override branch protections

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -27,6 +27,7 @@ on:
       - tests/**.py
       - tox.ini
       - xhydro/__init__.py
+  workflow_dispatch:
 
 jobs:
   bump_patch_version:
@@ -51,6 +52,6 @@ jobs:
       - name: Push Changes
         uses: ad-m/github-push-action@master
         with:
-          force: false
+          force: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}


### PR DESCRIPTION
## Changes

* Adds force push to override branch protections.
* Add "workflow_dispatch" to allow for manual version increases.

More information: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch