### PR TITLE
Update actions to reflect new primary branch name "main"

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -3,7 +3,7 @@ name: "Bump Patch Version"
 on:
   push:
     branches:
-      - master
+      - main
     paths-ignore:
       - .cruft.json
       - .editorconfig

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,10 +3,10 @@ name: Deploy Documentation
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 permissions:
   contents: write

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -36,7 +36,7 @@ Or download the `tarball`_:
 
 .. code-block:: console
 
-    $ curl -OJL https://github.com/hydrologie/xhydro/tarball/master
+    $ curl -OJL https://github.com/hydrologie/xhydro/tarball/main
 
 Once you have a copy of the source, you can install it with:
 
@@ -46,4 +46,4 @@ Once you have a copy of the source, you can install it with:
 
 
 .. _Github repo: https://github.com/hydrologie/xhydro
-.. _tarball: https://github.com/hydrologie/xhydro/tarball/master
+.. _tarball: https://github.com/hydrologie/xhydro/tarball/main


### PR DESCRIPTION
There has been pressure to change what the primary development branch should be in GitHub/GitLab (https://stevenmortimer.com/5-steps-to-change-github-default-branch-from-master-to-main/). The new cookiecutter was already adapted to `main`, so this should get all remaining workflows and docs onto the "main" page.