### PR TITLE
Better detection of fit params

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -20,11 +20,12 @@ Breaking changes
 
 Bug fixes
 ^^^^^^^^^
-* N/A
+* The `return_level` dimension in `xh.frequency_analysis.local.parametric_quantiles()` is not the actual return level, not the quantile (:issue:`41`, :pull:`43`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^
 * Added `xhydro.testing.utils.publish_release_notes()` to help with the release process. (:pull:`37`).
+* `xh.frequency_analysis.local.parametric_quantiles()` and `xh.frequency_analysis.local.criteria()` are now lazier (:issue:`41`, :pull:`43`).
 
 v0.2.0 (2023-10-10)
 -------------------

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -95,9 +95,7 @@ def test_quantiles(mode):
     else:
         rp = xhfa.local.parametric_quantiles(params, [10, 20], mode=mode)
 
-        np.testing.assert_array_equal(
-            rp.return_period, [0.9, 0.95] if mode == "max" else [0.1, 0.05]
-        )
+        np.testing.assert_array_equal(rp.return_period, [10, 20])
         np.testing.assert_array_equal(rp.scipy_dist, ["gamma", "pearson3"])
         assert rp.streamflow.attrs["long_name"] == "Distribution quantiles"
         assert (

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -96,13 +96,17 @@ def test_quantiles(mode):
         rp = xhfa.local.parametric_quantiles(params, [10, 20], mode=mode)
 
         np.testing.assert_array_equal(rp.return_period, [10, 20])
+        np.testing.assert_array_equal(
+            rp.p_quantile, [0.1, 0.05] if mode == "min" else [0.9, 0.95]
+        )
         np.testing.assert_array_equal(rp.scipy_dist, ["gamma", "pearson3"])
-        assert rp.streamflow.attrs["long_name"] == "Distribution quantiles"
+        assert rp.streamflow.attrs["long_name"] == "Return levels"
         assert (
             rp.streamflow.attrs["description"]
-            == "Quantiles estimated by statistic distributions"
+            == f"Return levels ({mode}) estimated by statistic distributions"
         )
         assert rp.streamflow.attrs["cell_methods"] == "dparams: ppf"
+        assert rp.streamflow.attrs["mode"] == mode
 
         ans = (
             [[190.66041057, 214.08102761], [185.78830382, 203.01731036]]

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -100,10 +100,10 @@ def test_quantiles(mode):
             rp.p_quantile, [0.1, 0.05] if mode == "min" else [0.9, 0.95]
         )
         np.testing.assert_array_equal(rp.scipy_dist, ["gamma", "pearson3"])
-        assert rp.streamflow.attrs["long_name"] == "Return levels"
+        assert rp.streamflow.attrs["long_name"] == "Return period"
         assert (
             rp.streamflow.attrs["description"]
-            == f"Return levels ({mode}) estimated by statistic distributions"
+            == f"Return period ({mode}) estimated by statistic distributions"
         )
         assert rp.streamflow.attrs["cell_methods"] == "dparams: ppf"
         assert rp.streamflow.attrs["mode"] == mode

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -103,7 +103,7 @@ def test_quantiles(mode):
         assert rp.streamflow.attrs["long_name"] == "Return period"
         assert (
             rp.streamflow.attrs["description"]
-            == f"Return period ({mode}) estimated by statistic distributions"
+            == f"Return period ({mode}) estimated with statistic distributions"
         )
         assert rp.streamflow.attrs["cell_methods"] == "dparams: ppf"
         assert rp.streamflow.attrs["mode"] == mode

--- a/xhydro/frequency_analysis/local.py
+++ b/xhydro/frequency_analysis/local.py
@@ -141,15 +141,15 @@ def parametric_quantiles(p, t: Union[float, list], mode: str = "max") -> xr.Data
         )
         da_q.attrs[
             "description"
-        ] = "Parametric distribution quantiles for the given return levels."
+        ] = "Parametric distribution quantiles for the given return period."
         da_q.attrs["mode"] = mode
         quantiles = quantiles.assign_coords(p_quantile=da_q)
 
         quantiles.attrs["scipy_dist"] = distributions
         quantiles.attrs[
             "description"
-        ] = f"Return levels ({mode}) estimated with statistic distributions"
-        quantiles.attrs["long_name"] = "Return levels"
+        ] = f"Return period ({mode}) estimated with statistic distributions"
+        quantiles.attrs["long_name"] = "Return period"
         quantiles.attrs["mode"] = mode
         out.append(quantiles)
 


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes #41
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] HISTORY.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Uses a lazier method to detect which parameters are associated to a given distribution.
* `parametric_quantiles` now returns the actual return_level (e.g. [10, 20]) instead of the quantile (e.g. [0.9, 0.95]).

### Does this PR introduce a breaking change?

- The `return_level` dimension has changed to the return level, instead of the quantile.

### Other information:
