### PR TITLE
Use organization-managed access tokens

### DIFF
--- a/.github/workflows/actions-versions-updater.yml
+++ b/.github/workflows/actions-versions-updater.yml
@@ -6,19 +6,26 @@ on:
     - cron:  '0 0 1 * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4.1.1
         with:
           # This requires a personal access token with the privileges to push directly to `main`
-          token: ${{ secrets.WORKFLOW_TOKEN }}
+          token: ${{ secrets.ACTIONS_VERSION_UPDATER_TOKEN }}
           persist-credentials: true
       - name: Run GitHub Actions Version Updater
         uses: saadmk11/github-actions-version-updater@v0.8.1
         with:
-          token: ${{ secrets.WORKFLOW_TOKEN }}
+          token: ${{ secrets.ACTIONS_VERSION_UPDATER_TOKEN }}
           committer_email: 'bumpversion[bot]@ouranos.ca'
           committer_username: 'update-github-actions[bot]'
           pull_request_title: '[bot] Update GitHub Action Versions'

--- a/.github/workflows/actions-versions-updater.yml
+++ b/.github/workflows/actions-versions-updater.yml
@@ -22,6 +22,7 @@ jobs:
           # This requires a personal access token with the privileges to push directly to `main`
           token: ${{ secrets.ACTIONS_VERSION_UPDATER_TOKEN }}
           persist-credentials: true
+
       - name: Run GitHub Actions Version Updater
         uses: saadmk11/github-actions-version-updater@v0.8.1
         with:

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -28,9 +28,15 @@ on:
       - xhydro/__init__.py
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   bump_patch_version:
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -54,5 +60,5 @@ jobs:
         uses: ad-m/github-push-action@master
         with:
           force: false
-          github_token: ${{ secrets.BUMPVERSION_TOKEN }}
+          github_token: ${{ secrets.BUMP_VERSION_TOKEN }}
           branch: ${{ github.ref }}

--- a/.github/workflows/first_pull_request.yml
+++ b/.github/workflows/first_pull_request.yml
@@ -5,10 +5,16 @@ on:
     types:
       - opened
 
+permissions:
+  contents: read
+
 jobs:
   welcome:
     name: Welcome
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/github-script@v6
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,10 @@ on:
       - xhydro/__init__.py
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   lint:
     name: Lint (Python${{ matrix.python-version }})

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -5,6 +5,9 @@ on:
     types:
       - published
 
+permissions:
+  contents: read
+
 jobs:
   build-n-publish-pypi:
     name: Build and publish Python 🐍 distributions 📦 to PyPI

--- a/.github/workflows/tag-testpypi.yml
+++ b/.github/workflows/tag-testpypi.yml
@@ -5,11 +5,16 @@ on:
     tags:
       - 'v*.*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Create Release from tag
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v') && endsWith(github.ref, '.0')
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,6 @@ filename = ".cruft.json"
 search = "\"version\": \"{current_version}\""
 replace = "\"version\": \"{new_version}\""
 
-
 [tool.coverage.run]
 relative_files = true
 include = ["xhydro/*"]


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [ ] CHANGES.rst has been updated (with summary of main changes).
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Updates Workflows to use Organization-scoped Access Tokens
* Updates workflow permissions to be very explicit (easier to understand what access is being used/asked for by each)

### Does this PR introduce a breaking change?

No.

### Other information:

The `ACTIONS_VERSIONS_UPDATER_TOKEN` and the `BUMP_VERSION_TOKEN` are Organization-scoped (`Hydrologie`) personal access tokens with the following permissions for repositories `xhydro`, `xdatasets` and `xhydro-testdata`:

ACTIONS_VERSIONS_UPDATER_TOKEN:
 - Contents: Read and Write
 - Metadata: Read-Only
 - Pull Requests: Read and Write
 - Workflows: Read and Write

BUMP_VERSION_TOKEN:
 - Contents: Read and Write
 - Metadata: Read-Only
 - Pull Requests: Read and Write

**Both are set to expire on January 1st, 2025**. After this point, anyone with maintainer access can generate new tokens and ask the `Hydrologie` admins to update the tokens so that workflows continue operating as normal.

For more information: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens