### PR TITLE
Fix tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,7 @@ Breaking changes
 
 Internal changes
 ^^^^^^^^^^^^^^^^
-* N/A
+* Tests using the `gamma` distribution were changed to the `gumbel_r` to avoid changes in `xclim v0.49.0`. (:pull:`145`).
 
 
 v0.3.5 (2024-03-20)

--- a/tests/test_gis.py
+++ b/tests/test_gis.py
@@ -24,7 +24,9 @@ class TestWatershedDelineation:
     )
     def test_watershed_delineation_from_coords(self, lng_lat, area):
         gdf = xh.gis.watershed_delineation(coordinates=lng_lat)
-        np.testing.assert_almost_equal([gdf.to_crs(32198).area.values[0]], [area])
+        np.testing.assert_almost_equal(
+            [gdf.to_crs(32198).area.values[0]], [area], decimal=3
+        )
 
     @pytest.mark.parametrize("area", [(18891676494.940426)])
     def test_watershed_delineation_from_map(self, area):
@@ -37,7 +39,9 @@ class TestWatershedDelineation:
             }
         ]
         gdf = xh.gis.watershed_delineation(map=self.m)
-        np.testing.assert_almost_equal([gdf.to_crs(32198).area.values[0]], [area])
+        np.testing.assert_almost_equal(
+            [gdf.to_crs(32198).area.values[0]], [area], decimal=3
+        )
 
     def test_errors(self):
         bad_coordinates = (-35.0, 45.0)
@@ -117,7 +121,7 @@ class TestWatershedOperations:
         output_dataset["gravelius"].attrs = {"units": "m/m"}
         output_dataset["centroid"].attrs = {"units": ("degree_east", "degree_north")}
 
-        xr.testing.assert_equal(ds_properties, output_dataset)
+        xr.testing.assert_allclose(ds_properties, output_dataset)
 
     @pytest.fixture
     def land_classification_data_latest(self):


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes #xyz
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] CHANGES.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Tests for the GIS module were too strict.
* Changes were made in `xclim v0.49.0` with how the `gamma` and `fisk` distributions were initiated in `xclim`, which changed the fitting results and parametric quantiles. It just so happened that we arbitrarily used the `gamma` for our tests. To be backwards-compatible, those tests were changed to the `gumbel_r`.

### Does this PR introduce a breaking change?

- No.

### Other information:
Changes to the `gamma` distribution:
https://github.com/Ouranosinc/xclim/issues/1477
https://github.com/Ouranosinc/xclim/pull/1720