### PR TITLE
Pin numpy below v2.0.0, bump RavenPy to v0.15.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ v.4.0 (unreleased)
 -------------------
 Contributors to this version: Trevor James Smith (:user:`Zeitsperre`).
 
+New features and enhancements
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* `xhydro` now supports `RavenPy` v0.15.0 (`RavenHydroFramework` v3.8.1). (:pull:`161`).
+
 Internal changes
 ^^^^^^^^^^^^^^^^
 * `numpy` has been pinned below v2.0.0 until `xclim` and other dependencies are updated to support it. (:pull:`161`).

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+v.4.0 (unreleased)
+-------------------
+Contributors to this version: Trevor James Smith (:user:`Zeitsperre`).
+
+Internal changes
+^^^^^^^^^^^^^^^^
+* `numpy` has been pinned below v2.0.0 until `xclim` and other dependencies are updated to support it. (:pull:`161`).
+
 v0.3.6 (2024-06-10)
 -------------------
 Contributors to this version: Gabriel Rondeau-Genesse (:user:`RondeauG`), Richard Arsenault (:user:`richardarsenault`), Sébastien Langlois (:user:`sebastienlanglois`).

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -10,7 +10,7 @@ dependencies:
   - haversine
   - intake <2.0.0 # This should be set by xdatasets once on conda-forge
   - leafmap
-  - numpy
+  - numpy <2.0.0
   - pandas
   - planetary-computer
   - pystac

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -19,7 +19,7 @@ dependencies:
   - pydantic >=2.0,<2.5.3  # FIXME: Remove pin once our dependencies (xclim, xscen) support pydantic 2.5.3
   - pyyaml
   - rasterio
-  - ravenpy
+  - ravenpy >=0.15.0
   - rioxarray
   - spotpy
   - stackstac

--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - pystac-client
   - pyyaml
   - rasterio
-  - ravenpy
+  - ravenpy >=0.15.0
   - rioxarray
   - spotpy
   - stackstac

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - haversine
   - intake <2.0.0 # This should be set by xdatasets once on conda-forge
   - leafmap
-  - numpy
+  - numpy <2.0.0
   - pandas
   - planetary-computer
   - pooch >=1.8.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
   "intake <2.0.0", # This should be set by xdatasets once on conda-forge
   "intake-esm !=2024.2.6", # pin needed for intake-esm (dependency of xscen) to work with Python3.9
   "leafmap",
-  "numpy",
+  "numpy <2.0.0",
   "pandas",
   "planetary-computer",
   "pooch >=1.8.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
   "pystac-client",
   "pyyaml",
   "rasterio",
-  "ravenpy",
+  "ravenpy >=0.15.0",
   "rioxarray",
   "spotpy",
   "stackstac",

--- a/tests/test_ravenpy_models.py
+++ b/tests/test_ravenpy_models.py
@@ -393,7 +393,8 @@ class TestRavenpyModels:
 
         if __raven_version__ == "3.8.1":
             warnings.warn("Blended model does not work with RavenHydroFramework v3.8.1")
-            rpm.run()
+            with pytest.raises(OSError):
+                rpm.run()
         else:
             qsim = rpm.run()
             assert qsim["streamflow"].shape == (1827,)

--- a/tests/test_ravenpy_models.py
+++ b/tests/test_ravenpy_models.py
@@ -1,9 +1,11 @@
 import datetime as dt
+import warnings
 
 import numpy as np
 import pooch
 import pytest
 import xarray as xr
+from raven_hydro import __raven_version__
 
 from xhydro.modelling import RavenpyModel
 
@@ -389,9 +391,12 @@ class TestRavenpyModels:
             evaporation=self.evaporation,
         )
 
-        qsim = rpm.run()
-
-        assert qsim["streamflow"].shape == (1827,)
+        if __raven_version__ == "3.8.1":
+            warnings.warn("Blended model does not work with RavenHydroFramework v3.8.1")
+            rpm.run()
+        else:
+            qsim = rpm.run()
+            assert qsim["streamflow"].shape == (1827,)
 
     def test_fake_ravenpy(self):
         """Test for GR4JCN ravenpy model"""


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Pins `numpy` below v2.0.0 until dependencies can address changes
* Updates the `RavenPy` version to v0.15.0 (`RavenHydroFramework` v3.8.1).

### Does this PR introduce a breaking change?

Yes, the "Blended" model in RavenHydroFramwork v3.8.1 is completely broken (Segmentation faults). I'm not sure how mission-critical that is here.
