### PR TITLE
yamllint fixes

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,6 +1,7 @@
 # Dependency Review Action
 #
-# This Action will scan dependency manifest files that change as part of a Pull Request, surfacing known-vulnerable versions of the packages declared or updated in the PR. Once installed, if the workflow run is marked as required, PRs introducing known-vulnerable packages will be blocked from merging.
+# This Action will scan dependency manifest files that change as part of a Pull Request, surfacing known-vulnerable versions of the packages declared or updated in the PR.
+# Once installed, if the workflow run is marked as required, PRs introducing known-vulnerable packages will be blocked from merging.
 #
 # Source repository: https://github.com/actions/dependency-review-action
 # Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,7 +135,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
     defaults:
       run:
         shell: bash -l {0}
@@ -204,7 +204,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-       python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
     defaults:
       run:
         shell: bash -l {0}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 default_language_version:
-    python: python3
+  python: python3
 
 repos:
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.16.0
     hooks:
-    -   id: pyupgrade
+      - id: pyupgrade
         args: [ '--py39-plus' ]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
@@ -46,7 +46,7 @@ repos:
     hooks:
       - id: ruff
         args: [ '--fix' ]
-#      - id: format
+      # - id: format
   - repo: https://github.com/pycqa/flake8
     rev: 7.1.0
     hooks:
@@ -83,7 +83,7 @@ repos:
     rev: v1.35.1
     hooks:
       - id: yamllint
-        args: ['--config-file=.yamllint.yaml']
+        args: [ '--config-file=.yamllint.yaml' ]
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.28.6
     hooks:
@@ -95,13 +95,13 @@ repos:
       - id: check-useless-excludes
 
 ci:
-    autofix_commit_msg: |
-        [pre-commit.ci] auto fixes from pre-commit.com hooks
+  autofix_commit_msg: |
+    [pre-commit.ci] auto fixes from pre-commit.com hooks
 
-        for more information, see https://pre-commit.ci
-    autofix_prs: true
-    autoupdate_branch: ''
-    autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
-    autoupdate_schedule: quarterly
-    skip: []
-    submodules: false
+    for more information, see https://pre-commit.ci
+  autofix_prs: true
+  autoupdate_branch: ''
+  autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
+  autoupdate_schedule: quarterly
+  skip: [ ]
+  submodules: false

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,8 +1,29 @@
 ---
 
 rules:
+
+  brackets:
+    forbid: false
+    min-spaces-inside: 1
+    max-spaces-inside: 1
+
   document-start: disable
+
+  float-values:
+    require-numeral-before-decimal: true
+
+  hyphens:
+    max-spaces-after: 1
+
+  indentation:
+    indent-sequences: whatever
+    spaces: consistent
+
+  key-duplicates:
+    forbid-duplicated-merge-keys: true
+
   line-length:
-    max: 120
+    max: 190
     level: warning
+
   truthy: disable

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -7,6 +7,9 @@ rules:
     min-spaces-inside: 1
     max-spaces-inside: 1
 
+  commas:
+    min-spaces-after: 1
+
   document-start: disable
 
   float-values:
@@ -23,7 +26,14 @@ rules:
     forbid-duplicated-merge-keys: true
 
   line-length:
-    max: 190
+    allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: true
+    max: 180
     level: warning
+
+  new-lines:
+    type: unix
+
+  trailing-spaces: {}
 
   truthy: disable

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Internal changes
 * A helper script has been added in the `CI` directory to facilitate the translation of the `xhydro` documentation. (:issue:`63`, :pull:`163`).
 * The `conda` environment now relies on the newly created `xdatasets` package. (:pull:`164`).
 * The cookiecutter has been updated to the latest commit. Changes include workflow fixes, stricter coding standards, and many small adjustments to the documentation. (:pull:`164`).
+* A previously uncaught YAML formatting issue has been addressed. Stricter style conventions are now enforced. (:pull:`174`).
 
 v0.3.6 (2024-06-10)
 -------------------


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Fixes the yamllint configuration and addresses inconsistencies that were silently ignored on Linux
* Implements a stricter and more consistent style

### Does this PR introduce a breaking change?

The yaml linting rule set is more strict about cosnistency:
- Line length has been bumped up to 180 characters (with exceptions for mappings and long words, such as URLs)
- Indentation must always be consistent
- Duplicate/mergeable keys are explicitly not allowed
- Brackets must always contain a leading and following space (for readability)
- Commas must always have a following space
- Newlines must always follow UNIX conventions
- Trailing spaces at the end of lines are not allowed (this is automatically addressed via pre-commit)

### Other information:

These rules will be merged upstream to the template and propagated elsewhere. Do we feel that they are too strict?