### PR TITLE
changed default scipy_dist to those giving similar results then Hyfran

### DIFF
--- a/src/xhydro/frequency_analysis/local.py
+++ b/src/xhydro/frequency_analysis/local.py
@@ -31,7 +31,7 @@ def fit(
         Dataset containing the data to fit. All variables will be fitted.
     distributions : list of str, optional
         List of distribution names as defined in `scipy.stats`. See https://docs.scipy.org/doc/scipy/reference/stats.html#continuous-distributions.
-        Defaults to ["expon", "gamma", "genextreme", "genpareto", "gumbel_r", "pearson3", "weibull_min"].
+        Defaults to ["genextreme", "pearson3", "gumbel_r", "expon"].
     min_years : int, optional
         Minimum number of years required for a distribution to be fitted.
     method : str
@@ -47,15 +47,7 @@ def fit(
     In order to combine the parameters of multiple distributions, the size of the `dparams` dimension is set to the
     maximum number of unique parameters between the distributions.
     """
-    distributions = distributions or [
-        "expon",
-        "gamma",
-        "genextreme",
-        "genpareto",
-        "gumbel_r",
-        "pearson3",
-        "weibull_min",
-    ]
+    distributions = distributions or ["genextreme", "pearson3", "gumbel_r", "expon"]
     out = []
     for v in ds.data_vars:
         p = []

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -46,20 +46,10 @@ class TestFit:
             as_dataset=True,
         )
         params = xhfa.local.fit(ds)
-        np.testing.assert_array_equal(
-            params.dparams, ["a", "c", "skew", "loc", "scale"]
-        )
+        np.testing.assert_array_equal(params.dparams, ["c", "skew", "loc", "scale"])
         np.testing.assert_array_equal(
             params.scipy_dist,
-            [
-                "expon",
-                "gamma",
-                "genextreme",
-                "genpareto",
-                "gumbel_r",
-                "pearson3",
-                "weibull_min",
-            ],
+            ["genextreme", "pearson3", "gumbel_r", "expon"],
         )
 
     @pytest.mark.parametrize("miny", [10, 15])


### PR DESCRIPTION
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)

### What kind of change does this PR introduce?
We default the fit function to the four laws giving the same results as RMCBestFit. For Hyfran, 3rd and 4th laws dont converge to the exact same parameters, but Scipy and RMCBest fit are probably more up to date.
