### PR TITLE
Improved the _ravenpy_models.py script to be able to specify the rain snow fraction for all models

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -21,6 +21,11 @@
       "name": "Arsenault, Richard",
       "affiliation": "École de technologie supérieure, Montréal, Québec, Canada",
       "orcid": "0000-0003-2834-2750"
+    },
+    {
+      "name": "Arnal, Louise",
+      "affiliation": "Ouranos",
+      "orcid": "0000-0002-0208-2324"
     }
   ],
   "keywords": [

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -19,3 +19,4 @@ Contributors
 
 * Richard Arsenault `@richardarsenault <https://github.com/richardarsenault>`_
 * Francis Gravel `@mayetea <https://github.com/mayetea>`_
+* Louise Arnal `@lou-a <https://github.com/lou-a>`_

--- a/src/xhydro/modelling/_ravenpy_models.py
+++ b/src/xhydro/modelling/_ravenpy_models.py
@@ -117,7 +117,7 @@ class RavenpyModel(HydrologicalModel):
                     data_kwds=meteo_station_properties,
                 )
             ],
-            RainSnowFraction=rain_snow_fraction,
+            rain_snow_fraction=rain_snow_fraction,
             Evaporation=evaporation,
             **kwargs,
         )
@@ -151,9 +151,6 @@ class RavenpyModel(HydrologicalModel):
         # Need to remove qobs as pydantic forbids extra inputs...
         if "qobs" in default_emulator_config:
             default_emulator_config.pop("qobs")
-
-        if model_name == "HBVEC":
-            default_emulator_config.pop("RainSnowFraction")
 
         self.model = getattr(ravenpy.config.emulators, model_name)(
             **default_emulator_config


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [ ] CHANGELOG.rst has been updated (with summary of main changes).
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

Improved the _ravenpy_models.py script to be able to specify the rain snow fraction for all models, including HBVEC. With the new version of RavenPy (v0.16.0, unreleased), the rain_snow_fraction could be set with "RainSnowFraction=rain_snow_fraction" in the self.default_emulator_config dictionary. See: https://github.com/CSHS-CWRA/RavenPy/pull/408. For now (based on the latest release RavenPy version, v0.15.0) the change I'm suggesting here will enable changing the rain snow fraction algorithm for HBVEC as well.

### Does this PR introduce a breaking change?

None foreseen.

### Other information:
