### PR TITLE
Major refactoring of sampled_indicators

### DIFF
--- a/docs/notebooks/climate_change.ipynb
+++ b/docs/notebooks/climate_change.ipynb
@@ -479,23 +479,12 @@
    "id": "26",
    "metadata": {},
    "source": [
-    "Because of their probabilistic nature, the historical reference values can't easily be combined to the future deltas. The `sampled_indicators` function has been created to circumvent this issue. That function will:\n",
+    "Because of their probabilistic nature, the historical reference values can't easily be combined to the future deltas. The `weighted_random_sampling` and `sampled_indicators` functions have been created to circumvent this issue. Together, these functions will:\n",
     "\n",
     "1. Sample 'n' values from the historical distribution, weighting the percentiles by their associated coverage.\n",
     "2. Sample 'n' values from the delta distribution, using the provided weights.\n",
     "3. Create the future distribution by applying the sampled deltas to the sampled historical distribution, element-wise.\n",
-    "4. Compute the percentiles of the future distribution.\n",
-    "\n",
-    "The inputs of that function are:\n",
-    "\n",
-    "- *ds*: Dataset containing the historical indicators. The indicators are expected to be represented by a distribution of pre-computed percentiles.\n",
-    "- *deltas*: Dataset containing the future deltas to apply to the historical indicators.\n",
-    "- *delta_kind*: Kind of delta provided. Must be one of ['absolute', 'percentage'].\n",
-    "- *ds_weights* (optional): Weights to use when sampling the historical indicators, for dimensions other than 'percentile'/'quantile'. Dimensions not present in this Dataset, or if None, will be sampled uniformly unless they are shared with 'deltas'.\n",
-    "- *delta_weights* (optional): Weights to use when sampling the deltas, such as along the 'realization' dimension. Dimensions not present in this Dataset, or if None, will be sampled uniformly unless they are shared with 'ds'.\n",
-    "- *n*: Number of samples to generate.\n",
-    "- *seed* (optional): Seed to use for the random number generator.\n",
-    "- *return_dist*: Whether to return the full distributions (ds, deltas, fut) or only the percentiles."
+    "4. Compute the percentiles of the future distribution."
    ]
   },
   {
@@ -505,23 +494,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "n = 300000\n",
-    "deltas = xclim.ensembles.create_ensemble(\n",
-    "    ds_dict_deltas\n",
-    ")  # The function expects an xarray object. This xclim function can be used to easily create the required input.\n",
-    "\n",
-    "# Compute the perturbed indicators\n",
-    "fut_pct, hist_dist, delta_dist, fut_dist = xh.cc.sampled_indicators(\n",
-    "    ref,\n",
-    "    deltas=deltas,\n",
-    "    delta_kind=\"percentage\",\n",
-    "    delta_weights=weights,\n",
-    "    n=n,\n",
-    "    seed=0,\n",
-    "    return_dist=True,\n",
-    ")\n",
-    "\n",
-    "fut_pct"
+    "print(xh.cc.weighted_random_sampling.__doc__)"
    ]
   },
   {
@@ -531,7 +504,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# First, let's show how the historical distribution was sampled and reconstructed\n",
+    "n = 10000\n",
+    "deltas = xclim.ensembles.create_ensemble(\n",
+    "    ds_dict_deltas\n",
+    ")  # The function expects an xarray object. This xclim function can be used to easily create the required input.\n",
+    "\n",
+    "# First, we sample within the reference dataset to combine the results of the 6 hydrological platforms together.\n",
+    "hist_dist = xh.cc.weighted_random_sampling(\n",
+    "    ds=ref,\n",
+    "    include_dims=[\"platform\"],\n",
+    "    n=n,\n",
+    "    seed=0,\n",
+    ")\n",
+    "\n",
+    "# Let's show how the historical distribution was sampled and reconstructed\n",
     "\n",
     "\n",
     "def _make_cdf(ds, bins):\n",
@@ -572,16 +558,32 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Then, let's show how the deltas were sampled, for the last horizon\n",
+    "# We can also inspect the array to see that the `platform` and `percentile` dimensions have indeed been reduced.\n",
+    "hist_dist"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "30",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# We can do the same for the deltas. Since `weights` already contains all dimensions that we want to sample from, we don't need `include_dims` here.\n",
+    "delta_dist = xh.cc.weighted_random_sampling(\n",
+    "    ds=deltas,\n",
+    "    weights=weights,\n",
+    "    n=n,\n",
+    "    seed=0,\n",
+    ")\n",
     "\n",
-    "# Plot #3\n",
+    "# Then, let's show how the deltas were sampled, for the last horizon\n",
     "plt.subplot(2, 1, 1)\n",
     "uniquen = np.unique(delta_dist.QMOYAN.isel(station=0, horizon=-1), return_counts=True)\n",
     "plt.bar(uniquen[0], uniquen[1], width=0.25, color=\"k\")\n",
     "plt.ylabel(\"Number of instances\")\n",
     "plt.title(\"Sampling within the historical distribution\")\n",
     "\n",
-    "# Plot #2\n",
     "plt.subplot(2, 1, 2)\n",
     "bc, c = _make_cdf(delta_dist, bins=100)\n",
     "plt.plot(bc[1:], c, \"k\", label=f\"Sampled deltas CDF (n={n})\", linewidth=3)\n",
@@ -595,11 +597,70 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# The distributions can be used to quickly create boxplots\n",
+    "# We can inspect the results here too.\n",
+    "delta_dist"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32",
+   "metadata": {},
+   "source": [
+    "Once the two distributions have been acquired, `xh.cc.sampled_indicators` can be used to combine them element-wise and reconstruct a future distribution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(xh.cc.sampled_indicators.__doc__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "34",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fut_dist, fut_pct = xh.cc.sampled_indicators(\n",
+    "    ds_dist=hist_dist,\n",
+    "    deltas_dist=delta_dist,\n",
+    "    delta_kind=\"percentage\",\n",
+    "    percentiles=ref.percentile,\n",
+    ")\n",
+    "\n",
+    "# The resulting distribution will possess the unique dimensions from both datasets.\n",
+    "# Here, this means that we get a reconstructed distribution for each future horizon.\n",
+    "fut_dist"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Since we used the `percentiles` argument, it also computed a series of percentiles.\n",
+    "fut_pct"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The distributions themselves can be used to create boxplots and compare the historucal distribution to the future ones.\n",
     "plt.boxplot(\n",
     "    [\n",
     "        hist_dist.QMOYAN.isel(station=0),\n",
@@ -617,7 +678,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/src/xhydro/cc.py
+++ b/src/xhydro/cc.py
@@ -1,5 +1,6 @@
 """Module to compute climate change statistics using xscen functions."""
 
+import os
 from datetime import datetime
 
 import numpy as np
@@ -15,143 +16,85 @@ __all__ = [
     "ensemble_stats",
     "produce_horizon",
     "sampled_indicators",
+    "weighted_random_sampling",
 ]
 
 
-def sampled_indicators(  # noqa: C901
+def weighted_random_sampling(
     ds: xr.Dataset,
-    deltas: xr.Dataset,
     *,
-    delta_kind: str | dict | None = None,
-    ds_weights: xr.DataArray | None = None,
-    delta_weights: xr.DataArray | None = None,
-    n: int = 50000,
+    weights: xr.DataArray | None = None,
+    include_dims: list[str] | None = None,
+    n: int = 5000,
     seed: int | None = None,
-    return_dist: bool = False,
-) -> xr.Dataset | tuple[xr.Dataset, xr.Dataset, xr.Dataset, xr.Dataset]:
-    """Compute future indicators using a perturbation approach and random sampling.
+) -> xr.Dataset:
+    """Sample from a dataset using random sampling.
 
     Parameters
     ----------
     ds : xr.Dataset
-        Dataset containing the historical indicators. The indicators are expected to be represented by a distribution of pre-computed percentiles.
-        The percentiles should be stored in either a dimension called "percentile" [0, 100] or "quantile" [0, 1].
-    deltas : xr.Dataset
-        Dataset containing the future deltas to apply to the historical indicators.
-    delta_kind : str or dict, optional
-        Type of delta provided. Recognized values are: ['absolute', 'abs.', '+'], ['percentage', 'pct.', '%'].
-        If a dict is provided, it should map the variable names to their respective delta type.
-        If None, the variables should have a 'delta_kind' attribute.
-    ds_weights : xr.DataArray, optional
-        Weights to use when sampling the historical indicators, for dimensions other than 'percentile'/'quantile'.
-        Dimensions not present in this Dataset, or if None, will be sampled uniformly unless they are shared with 'deltas'.
-    delta_weights : xr.DataArray, optional
-        Weights to use when sampling the deltas, such as along the 'realization' dimension.
-        Dimensions not present in this Dataset, or if None, will be sampled uniformly unless they are shared with 'ds'.
+        Dataset to sample from. See Notes for more information on special cases for 'percentile', 'quantile', 'time', and 'horizon' dimensions.
+    weights : xr.DataArray, optional
+        Weights to use when sampling the dataset for dimensions other than 'percentile'/'quantile'.
+    include_dims : list of str, optional
+        List of dimensions to include when sampling the dataset, in addition to the 'percentile'/'quantile' dimensions and those with weights.
     n : int
         Number of samples to generate.
     seed : int, optional
         Seed to use for the random number generator.
-    return_dist : bool
-        Whether to return the full distributions (ds, deltas, fut) or only the percentiles.
 
     Returns
     -------
-    fut_pct : xr.Dataset
-        Dataset containing the future percentiles.
-    ds_dist : xr.Dataset
-        The historical distribution, stacked along the 'sample' dimension.
-    deltas_dist : xr.Dataset
-        The delta distribution, stacked along the 'sample' dimension.
-    fut_dist : xr.Dataset
-        The future distribution, stacked along the 'sample' dimension.
+    xr.Dataset
+        Dataset containing the 'n' samples, stacked along a 'sample' dimension.
 
     Notes
     -----
+    If the dataset contains a "percentile" [0, 100] or "quantile" [0, 1] dimension, the percentiles will be sampled accordingly as to
+    account for the uneven spacing between percentiles and maintain the distribution's shape.
+
     Weights along the 'time' or 'horizon' dimensions are supported, but behave differently than other dimensions. They will not
     be stacked alongside other dimensions in the new 'sample' dimension. Rather, a separate sampling will be done for each time/horizon,
-
-    The future percentiles are computed as follows:
-    1. Sample 'n' values from the historical distribution, weighting the percentiles by their associated coverage.
-    2. Sample 'n' values from the delta distribution, using the provided weights.
-    3. Create the future distribution by applying the sampled deltas to the sampled historical distribution, element-wise.
-    4. Compute the percentiles of the future distribution.
     """
     # Prepare weights
-    shared_dims = set(ds.dims).intersection(set(deltas.dims))
-    exclude_dims = ["time", "horizon"]
-    percentile_weights = _percentile_weights(ds)
-    if ds_weights is not None:
-        percentile_weights = (
-            percentile_weights.expand_dims(
-                {dim: ds_weights[dim] for dim in ds_weights.dims}
-            )
-            * ds_weights
-        )
-    percentile_weights = percentile_weights.expand_dims(
-        {
-            dim: ds[dim]
-            for dim in set(ds.dims).difference(
-                list(shared_dims) + list(percentile_weights.dims) + exclude_dims
-            )
-        }
-    )
-    deltas_weighted = True
-    if delta_weights is None:
-        deltas_weighted = False
-        dims = set(deltas.dims).difference(list(shared_dims) + exclude_dims)
-        delta_weights = xr.DataArray(
-            np.ones([deltas.sizes[dim] for dim in dims]),
-            coords={dim: deltas[dim] for dim in dims},
-            dims=dims,
-        )
-    delta_weights = delta_weights.expand_dims(
-        {
-            dim: deltas[dim]
-            for dim in set(deltas.dims).difference(
-                list(shared_dims) + list(delta_weights.dims) + exclude_dims
-            )
-        }
-    )
+    include_dims = include_dims or []
 
-    unique_dims = set(percentile_weights.dims).symmetric_difference(
-        set(delta_weights.dims)
-    )
-    if any([dim in shared_dims for dim in unique_dims]):
-        problem_dims = [dim for dim in unique_dims if dim in shared_dims]
-        raise ValueError(
-            f"Dimension(s) {problem_dims} is shared between 'ds' and 'deltas', but not between 'ds_weights' and 'delta_weights'."
+    if weights is not None:
+        was_weighted = True
+        # Add weights along all dimensions not in 'exclude_dims'
+        weights = weights.expand_dims(
+            {dim: ds[dim] for dim in include_dims if dim not in weights.dims}
+        )
+    else:
+        was_weighted = False
+        # Uniform sampling for all dimensions in 'include_dims'
+        weights = xr.DataArray(
+            np.ones([ds.sizes[dim] for dim in include_dims]),
+            coords={dim: ds[dim] for dim in include_dims},
+            dims=include_dims,
         )
 
-    # Prepare the operation to apply on the variables
-    if delta_kind is None:
-        try:
-            delta_kind = {
-                var: deltas[var].attrs["delta_kind"] for var in deltas.data_vars
-            }
-        except KeyError:
-            raise KeyError(
-                "The 'delta_kind' argument is None, but the variables within the 'deltas' Dataset are missing a 'delta_kind' attribute."
-            )
-    elif isinstance(delta_kind, str):
-        delta_kind = {var: delta_kind for var in deltas.data_vars}
-    elif isinstance(delta_kind, dict):
-        if not all([var in delta_kind for var in deltas.data_vars]):
-            raise ValueError(
-                f"If 'delta_kind' is a dict, it should contain all the variables in 'deltas'. Missing variables: "
-                f"{list(set(deltas.data_vars) - set(delta_kind))}."
-            )
+    # Add the percentile weights
+    if any([dim in ds.dims for dim in ["percentile", "quantile"]]):
+        percentile_weights = _percentile_weights(ds)
+
+        weights = (
+            percentile_weights.expand_dims({dim: weights[dim] for dim in weights.dims})
+            * weights
+        )
+
+    if len(weights.dims) == 0:
+        raise ValueError("No weights provided for sampling.")
 
     def _add_sampling_attrs(d, prefix, history, ds_for_attrs=None):
         for var in d.data_vars:
             if ds_for_attrs is not None:
                 d[var].attrs = ds_for_attrs[var].attrs
-            d[var].attrs["sampling_kind"] = delta_kind[var]
             d[var].attrs["sampling_n"] = n
             d[var].attrs["sampling_seed"] = seed
             d[var].attrs[
                 "description"
-            ] = f"{prefix} of {d[var].attrs.get('long_name', var)} constructed from a perturbation approach and random sampling."
+            ] = f"{prefix} of {d[var].attrs.get('long_name', var)} constructed using random sampling."
             d[var].attrs[
                 "long_name"
             ] = f"{prefix} of {d[var].attrs.get('long_name', var)}"
@@ -161,38 +104,106 @@ def sampled_indicators(  # noqa: C901
             ] = f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] {history}\n {old_history}"
 
     # Sample the distributions
-    _, pdim, mult = _perc_or_quantile(ds)
     ds_dist = (
-        _weighted_sampling(ds, percentile_weights, n=n, seed=seed)
+        _weighted_sampling(ds, weights, n=n, seed=seed)
         .drop_vars("sample", errors="ignore")
         .assign_coords({"sample": np.arange(n)})
     )
     _add_sampling_attrs(
         ds_dist,
-        "Historical distribution",
-        f"{'Weighted' if ds_weights is not None else 'Uniform'} random sampling "
-        f"applied to the historical distribution using 'xhydro.sampled_indicators' "
-        f"and {n} samples.",
+        "Sampled distribution",
+        f"{'Weighted' if was_weighted else 'Uniform'} random sampling "
+        f"applied using 'xhydro.sampled_indicators' and {n} samples.",
         ds_for_attrs=ds,
     )
 
-    deltas_dist = (
-        _weighted_sampling(deltas, delta_weights, n=n, seed=seed)
-        .drop_vars("sample", errors="ignore")
-        .assign_coords({"sample": np.arange(n)})
-    )
-    _add_sampling_attrs(
-        deltas_dist,
-        "Future delta distribution",
-        f"{'Weighted' if deltas_weighted else 'Uniform'} random sampling "
-        f"applied to the delta distribution using 'xhydro.sampled_indicators' "
-        f"and {n} samples.",
-        ds_for_attrs=deltas,
-    )
+    return ds_dist
+
+
+def sampled_indicators(  # noqa: C901
+    ds_dist: xr.Dataset,
+    deltas_dist: xr.Dataset,
+    *,
+    delta_kind: str | dict | None = None,
+    percentiles: xr.DataArray | xr.Dataset | list[int] | np.ndarray | None = None,
+) -> xr.Dataset | tuple[xr.Dataset, xr.Dataset]:
+    """Reconstruct indicators using a perturbation approach and random sampling.
+
+    Parameters
+    ----------
+    ds_dist : xr.Dataset
+        Dataset containing the sampled reference distribution, stacked along a 'sample' dimension.
+        Typically generated using 'xhydro.cc.weighted_random_sampling'.
+    deltas_dist : xr.Dataset
+        Dataset containing the sampled deltas, stacked along a 'sample' dimension.
+        Typically generated using 'xhydro.cc.weighted_random_sampling'.
+    delta_kind : str or dict, optional
+        Type of delta provided. Recognized values are: ['absolute', 'abs.', '+'], ['percentage', 'pct.', '%'].
+        If a dict is provided, it should map the variable names to their respective delta type.
+        If None, the variables should have a 'delta_kind' attribute.
+    percentiles : xr.DataArray or xr.Dataset or list or np.ndarray, optional
+        Percentiles to compute in the future distribution.
+        This will change the output of the function to a tuple containing the future distribution and the future percentiles.
+        If given a Dataset, it should contain a 'percentile' or 'quantile' dimension.
+        If given a list or np.ndarray, it should contain percentiles [0, 100].
+
+    Returns
+    -------
+    fut_dist : xr.Dataset
+        The future distribution, stacked along the 'sample' dimension.
+    fut_pct : xr.Dataset
+        Dataset containing the future percentiles.
+
+    Notes
+    -----
+    The future percentiles are computed as follows:
+    1. Sample 'n' values from the reference distribution.
+    2. Sample 'n' values from the delta distribution.
+    3. Create the future distribution by applying the sampled deltas to the sampled historical distribution, element-wise.
+    4. Compute the percentiles of the future distribution (optional).
+    """
+    # Prepare the operation to apply on the variables
+    if delta_kind is None:
+        try:
+            delta_kind = {
+                var: deltas_dist[var].attrs["delta_kind"]
+                for var in deltas_dist.data_vars
+            }
+        except KeyError:
+            raise KeyError(
+                "The 'delta_kind' argument is None, but the variables within the 'deltas' Dataset are missing a 'delta_kind' attribute."
+            )
+    elif isinstance(delta_kind, str):
+        delta_kind = {var: delta_kind for var in deltas_dist.data_vars}
+    elif isinstance(delta_kind, dict):
+        if not all([var in delta_kind for var in deltas_dist.data_vars]):
+            raise ValueError(
+                f"If 'delta_kind' is a dict, it should contain all the variables in 'deltas'. Missing variables: "
+                f"{list(set(deltas_dist.data_vars) - set(delta_kind))}."
+            )
+
+    def _add_sampling_attrs(d, prefix, history, ds_for_attrs=None):
+        for var in d.data_vars:
+            if ds_for_attrs is not None:
+                d[var].attrs = ds_for_attrs[var].attrs
+            d[var].attrs["delta_kind"] = delta_kind[var]
+            var_name = (
+                d[var]
+                .attrs.get("long_name", var)
+                .replace("Sampled distribution of ", "")
+            )
+            d[var].attrs[
+                "description"
+            ] = f"{prefix} of {var_name} constructed from a perturbation approach and random sampling."
+            d[var].attrs["long_name"] = f"{prefix} of {var_name}"
+            old_history = d[var].attrs.get("history", "")
+            d[var].attrs[
+                "history"
+            ] = f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] {history}\n {old_history}"
 
     # Apply the deltas element-wise to the historical distribution
     fut_dist = xr.Dataset()
-    for var in deltas.data_vars:
+    for var in deltas_dist.data_vars:
         with xr.set_options(keep_attrs=True):
             if delta_kind[var] in ["absolute", "abs.", "+"]:
                 fut_dist[var] = ds_dist[var] + deltas_dist[var]
@@ -204,32 +215,40 @@ def sampled_indicators(  # noqa: C901
                 )
             _add_sampling_attrs(
                 fut_dist,
-                "Future distribution",
-                f"Future distribution constructed from a perturbation approach and random sampling with {n} samples.",
-                ds_for_attrs=ds,
+                "Reconstructed distribution",
+                f"Reconstructed distribution using a perturbation approach and random sampling.",
+                ds_for_attrs=ds_dist,
             )
 
     # Build the attributes based on common attributes between the historical and delta distributions
-    fut_dist = xs.clean_up(fut_dist, common_attrs_only=[ds, deltas])
+    fut_dist = xs.clean_up(fut_dist, common_attrs_only=[ds_dist, deltas_dist])
 
     # Compute future percentiles
-    with xr.set_options(keep_attrs=True):
-        fut_pct = fut_dist.quantile(ds.percentile / mult, dim="sample")
-    _add_sampling_attrs(
-        fut_pct,
-        "Future percentiles",
-        f"Future percentiles computed from the future distribution using 'xhydro.sampled_indicators' and {n} samples.",
-        ds_for_attrs=ds,
-    )
+    if percentiles is not None:
+        if isinstance(percentiles, list | np.ndarray):
+            if isinstance(percentiles, list):
+                percentiles = np.array(percentiles)
+            pdim = "percentile"
+            mult = 100
+        else:
+            _, pdim, mult = _perc_or_quantile(percentiles)
 
-    if pdim == "percentile":
-        fut_pct = fut_pct.rename({"quantile": "percentile"})
-        fut_pct["percentile"] = ds.percentile
+        with xr.set_options(keep_attrs=True):
+            fut_pct = fut_dist.quantile(percentiles / mult, dim="sample")
+        _add_sampling_attrs(
+            fut_pct,
+            "Reconstructed percentiles",
+            f"Reconstructed percentiles computed from the reconstructeddistribution using 'xhydro.sampled_indicators'.",
+            ds_for_attrs=ds_dist,
+        )
 
-    if return_dist:
-        return fut_pct, ds_dist, deltas_dist, fut_dist
-    else:
-        return fut_pct
+        if pdim == "percentile":
+            fut_pct = fut_pct.rename({"quantile": "percentile"})
+            fut_pct["percentile"] = percentiles
+
+        return fut_dist, fut_pct
+
+    return fut_dist
 
 
 def _percentile_weights(da: xr.DataArray | xr.Dataset) -> xr.DataArray:
@@ -263,7 +282,7 @@ def _percentile_weights(da: xr.DataArray | xr.Dataset) -> xr.DataArray:
 
 
 def _weighted_sampling(
-    ds: xr.Dataset, weights: xr.DataArray, n: int = 50000, seed: int | None = None
+    ds: xr.Dataset, weights: xr.DataArray, n: int = 5000, seed: int | None = None
 ) -> xr.Dataset:
     """Sample from a distribution with weights.
     In the case of weights on a 'time' or 'horizon' dimension, the sampling is done separately for each time/horizon, but with the same seed.
@@ -303,35 +322,44 @@ def _weighted_sampling(
     # For performance reasons, remove the chunking along impacted dimensions
     ds = ds.chunk({dim: -1 for dim in weights.dims})
     weights = weights.chunk({dim: -1 for dim in weights.dims})
+    # Load coordinates and weights to avoid issues with dask
+    [ds[c].load() for c in ds.coords]
+    weights = weights.compute()
 
     # Stack the dimensions containing weights
     ds = ds.stack({"sample": sorted(other_dims)})
     weights = weights.stack({"sample": sorted(other_dims)})
     weights = weights.reindex_like(ds)
+    ds = ds.drop_vars(["sample"] + other_dims).assign_coords(
+        {"sample": np.arange(len(ds.sample))}
+    )
+    weights = weights.drop_vars(["sample"] + other_dims).assign_coords(
+        {"sample": np.arange(len(weights.sample))}
+    )
 
     # Sample the dimensions with weights
     rng = np.random.default_rng(seed=seed)
 
+    # Perform the sampling
     if not time_dim:
         idx = rng.choice(len(weights.sample), size=n, p=weights)
-        # Create the distribution dataset
-        ds_dist = ds.isel({"sample": idx}).chunk({"sample": -1})
+        ds_dist = ds.chunk({"sample": -1}).reindex({"sample": idx})
+        ds_dist["sample"] = np.arange(len(ds_dist.sample))
+        ds_dist = ds_dist.chunk({"sample": -1})
+
     else:
-        # 2D weights are not supported by np.random.choice, so we need to loop over the time dimension
-        ds_tmp = [
-            ds.sel({time_dim: time}).isel(
-                {
-                    "sample": rng.choice(
-                        len(weights.sample), size=n, p=weights.sel({time_dim: time})
-                    )
-                }
+        ds_dist = []
+        for time in ds[time_dim].values:
+            idx = rng.choice(
+                len(weights.sample), size=n, p=weights.sel({time_dim: time})
             )
-            for time in ds[time_dim].values
-        ]
-        # Remove the coordinates from the sample dimension to allow concatenation
-        for i, ds_ in enumerate(ds_tmp):
-            ds_tmp[i] = ds_.reset_index("sample", drop=True)
-        ds_dist = xr.concat(ds_tmp, dim=time_dim).chunk({time_dim: -1, "sample": -1})
+            ds_dist_tmp = (
+                ds.sel({time_dim: time}).chunk({"sample": -1}).reindex({"sample": idx})
+            )
+            ds_dist_tmp["sample"] = np.arange(len(ds_dist_tmp.sample))
+            ds_dist_tmp = ds_dist_tmp.chunk({"sample": -1})
+            ds_dist.append(ds_dist_tmp)
+        ds_dist = xr.concat(ds_dist, dim=time_dim)
 
     return ds_dist
 

--- a/tests/test_cc.py
+++ b/tests/test_cc.py
@@ -35,54 +35,68 @@ class TestSampledIndicators:
             with pytest.raises(
                 KeyError, match="argument is None, but the variables within the"
             ):
-                xh.cc.sampled_indicators(
-                    ds, deltas, delta_kind=delta_kind, n=10, seed=42
+                ds_dist = xh.cc.weighted_random_sampling(ds, n=10, seed=42)
+                deltas_dist = xh.cc.weighted_random_sampling(
+                    deltas, n=10, seed=42, include_dims=["realization"]
                 )
+
+                xh.cc.sampled_indicators(ds_dist, deltas_dist, delta_kind=delta_kind)
             deltas["QMOYAN"].attrs["delta_kind"] = "absolute"
 
         if delta_kind in ["absolute", "percentage"] or delta_kind is None:
+            ds_dist = xh.cc.weighted_random_sampling(ds, n=10, seed=42)
+            deltas_dist = xh.cc.weighted_random_sampling(
+                deltas, n=10, seed=42, include_dims=["realization"]
+            )
             out = xh.cc.sampled_indicators(
-                ds, deltas, delta_kind=delta_kind, n=10, seed=42, return_dist=True
+                ds_dist, deltas_dist, delta_kind=delta_kind, percentiles=ds.percentile
             )
 
             np.testing.assert_array_equal(
-                out[0]["percentile"], [1, 10, 20, 50, 80, 90, 99]
+                out[1]["percentile"], [1, 10, 20, 50, 80, 90, 99]
             )
             assert all(
-                chosen in np.arange(1, 8) for chosen in np.unique(out[1].QMOYAN.values)
+                chosen in np.arange(1, 8) for chosen in np.unique(ds_dist.QMOYAN.values)
             )
             assert all(
                 chosen in np.arange(-10, 55, 5)
-                for chosen in np.unique(out[2].QMOYAN.values)
+                for chosen in np.unique(deltas_dist.QMOYAN.values)
             )
 
             if delta_kind == "absolute" or delta_kind is None:
                 assert (
-                    np.min(out[3].QMOYAN) >= 1 - 10
+                    np.min(out[0].QMOYAN) >= 1 - 10
                 )  # Min of historical minus min of deltas
                 assert (
-                    np.max(out[3].QMOYAN) <= 7 + 50
+                    np.max(out[0].QMOYAN) <= 7 + 50
                 )  # Max of historical plus max of deltas
                 np.testing.assert_array_almost_equal(
-                    out[0]["QMOYAN"].values, [-3.0, -3.0, 14.6, 40.0, 46.2, 51.6, 56.46]
+                    out[1]["QMOYAN"].values, [-3.0, -3.0, 14.6, 40.0, 46.2, 51.6, 56.46]
                 )
             else:
-                assert np.min(out[3].QMOYAN) >= 1 * (
+                assert np.min(out[0].QMOYAN) >= 1 * (
                     1 - 10 / 100
                 )  # Min of historical minus min of deltas
-                assert np.max(out[3].QMOYAN) <= 7 * (
+                assert np.max(out[0].QMOYAN) <= 7 * (
                     1 + 50 / 100
                 )  # Max of historical plus max of deltas
                 np.testing.assert_array_almost_equal(
-                    out[0]["QMOYAN"].values, [1.9, 1.9, 4.06, 6.75, 7.34, 8.88, 10.338]
+                    out[1]["QMOYAN"].values, [1.9, 1.9, 4.06, 6.75, 7.34, 8.88, 10.338]
                 )
 
         else:
             with pytest.raises(
                 ValueError, match=f"Unknown operation '{delta_kind}', expected one"
             ):
+                ds_dist = xh.cc.weighted_random_sampling(ds, n=10, seed=42)
+                deltas_dist = xh.cc.weighted_random_sampling(
+                    deltas, n=10, seed=42, include_dims=["realization"]
+                )
                 xh.cc.sampled_indicators(
-                    ds, deltas, delta_kind=delta_kind, n=10, seed=42
+                    ds_dist,
+                    deltas_dist,
+                    delta_kind=delta_kind,
+                    percentiles=ds.percentile,
                 )
 
     @pytest.mark.parametrize("dk", ["dict", "dict_bad", None])
@@ -110,47 +124,54 @@ class TestSampledIndicators:
             deltas["QMOYAN"].attrs["delta_kind"] = "pct."
             deltas["QMOYABS"].attrs["delta_kind"] = "abs."
 
+        ds_dist = xh.cc.weighted_random_sampling(ds, n=10, seed=42)
+        deltas_dist = xh.cc.weighted_random_sampling(
+            deltas, n=10, seed=42, include_dims=["realization"]
+        )
         if dk == "dict_bad":
             with pytest.raises(
                 ValueError, match="is a dict, it should contain all the variables"
             ):
                 xh.cc.sampled_indicators(
-                    ds, deltas, delta_kind=delta_kind, n=10, seed=42, return_dist=True
+                    ds_dist,
+                    deltas_dist,
+                    delta_kind=delta_kind,
+                    percentiles=ds.percentile,
                 )
         else:
             out = xh.cc.sampled_indicators(
-                ds, deltas, delta_kind=delta_kind, n=10, seed=42, return_dist=True
+                ds_dist, deltas_dist, delta_kind=delta_kind, percentiles=ds.percentile
             )
 
             np.testing.assert_array_equal(
-                out[0]["percentile"], [1, 10, 20, 50, 80, 90, 99]
+                out[1]["percentile"], [1, 10, 20, 50, 80, 90, 99]
             )
             assert all(
-                chosen in np.arange(1, 8) for chosen in np.unique(out[1].QMOYAN.values)
+                chosen in np.arange(1, 8) for chosen in np.unique(ds_dist.QMOYAN.values)
             )
             assert all(
                 chosen in np.arange(-10, 55, 5)
-                for chosen in np.unique(out[2].QMOYAN.values)
+                for chosen in np.unique(deltas_dist.QMOYAN.values)
             )
 
             assert (
-                np.min(out[3].QMOYABS) >= 1 - 10
+                np.min(out[0].QMOYABS) >= 1 - 10
             )  # Min of historical minus min of deltas
             assert (
-                np.max(out[3].QMOYABS) <= 7 + 50
+                np.max(out[0].QMOYABS) <= 7 + 50
             )  # Max of historical plus max of deltas
             np.testing.assert_array_almost_equal(
-                out[0]["QMOYABS"].values, [-3.0, -3.0, 14.6, 40.0, 46.2, 51.6, 56.46]
+                out[1]["QMOYABS"].values, [-3.0, -3.0, 14.6, 40.0, 46.2, 51.6, 56.46]
             )
 
-            assert np.min(out[3].QMOYAN) >= 1 * (
+            assert np.min(out[0].QMOYAN) >= 1 * (
                 1 - 10 / 100
             )  # Min of historical minus min of deltas
-            assert np.max(out[3].QMOYAN) <= 7 * (
+            assert np.max(out[0].QMOYAN) <= 7 * (
                 1 + 50 / 100
             )  # Max of historical plus max of deltas
             np.testing.assert_array_almost_equal(
-                out[0]["QMOYAN"].values, [1.9, 1.9, 4.06, 6.75, 7.34, 8.88, 10.338]
+                out[1]["QMOYAN"].values, [1.9, 1.9, 4.06, 6.75, 7.34, 8.88, 10.338]
             )
 
     def test_sampled_indicators_return(self):
@@ -162,19 +183,24 @@ class TestSampledIndicators:
             coords={"realization": np.arange(13)},
         ).to_dataset(name="QMOYAN")
 
-        out1 = xh.cc.sampled_indicators(
-            ds, deltas, delta_kind="absolute", n=10, seed=42, return_dist=False
+        ds_dist = xh.cc.weighted_random_sampling(ds, n=10, seed=42)
+        deltas_dist = xh.cc.weighted_random_sampling(
+            deltas, n=10, seed=42, include_dims=["realization"]
         )
+        out1 = xh.cc.sampled_indicators(ds_dist, deltas_dist, delta_kind="absolute")
         assert isinstance(out1, xr.Dataset)
 
         out2 = xh.cc.sampled_indicators(
-            ds, deltas, delta_kind="absolute", n=10, seed=42, return_dist=True
+            ds_dist,
+            deltas_dist,
+            delta_kind="absolute",
+            percentiles=[1, 10, 20, 50, 80, 90, 99],
         )
         assert isinstance(out2, tuple)
-        assert len(out2) == 4
+        assert len(out2) == 2
         assert all(isinstance(o, xr.Dataset) for o in out2)
         assert out2[0].equals(out1)
-        for o in out2[1:]:
+        for o in [out2[0], ds_dist, deltas_dist]:
             assert list(o.dims) == ["sample"]
             assert len(o["sample"]) == 10
 
@@ -236,69 +262,83 @@ class TestSampledIndicators:
         )
 
         if weights is None:
+            ds_dist = xh.cc.weighted_random_sampling(
+                ds, n=10, seed=42, include_dims=["foo"]
+            )
+            deltas_dist = xh.cc.weighted_random_sampling(
+                deltas, n=10, seed=42, include_dims=["realization", "platform"]
+            )
             out = xh.cc.sampled_indicators(
-                ds, deltas, delta_kind="percentage", n=10, seed=42, return_dist=True
+                ds_dist, deltas_dist, delta_kind="percentage", percentiles=ds.percentile
             )
             np.testing.assert_array_almost_equal(
-                out[0].QMOYAN.isel(station=0).values, [1.809, 5.5, 11.8, 12.0, 15.8155]
+                out[1].QMOYAN.isel(station=0).values, [1.809, 5.5, 11.8, 12.0, 15.8155]
             )
         elif weights == "ds":
+            ds_dist = xh.cc.weighted_random_sampling(
+                ds, weights=ds_weights, n=10, seed=42
+            )
+            deltas_dist = xh.cc.weighted_random_sampling(
+                deltas, n=10, seed=42, include_dims=["realization", "platform"]
+            )
             out = xh.cc.sampled_indicators(
-                ds,
-                deltas,
+                ds_dist,
+                deltas_dist,
                 delta_kind="percentage",
-                n=10,
-                seed=42,
-                return_dist=True,
-                ds_weights=ds_weights,
+                percentiles=ds.percentile,
             )
             np.testing.assert_array_almost_equal(
-                out[0].QMOYAN.isel(station=0).values,
+                out[1].QMOYAN.isel(station=0).values,
                 [5.427, 8.8, 13.275, 13.5, 15.8155],
             )
         elif weights == "deltas":
+            ds_dist = xh.cc.weighted_random_sampling(
+                ds, n=10, seed=42, include_dims=["foo"]
+            )
+            deltas_dist = xh.cc.weighted_random_sampling(
+                deltas, weights=delta_weights, n=10, seed=42
+            )
             out = xh.cc.sampled_indicators(
-                ds,
-                deltas,
+                ds_dist,
+                deltas_dist,
                 delta_kind="percentage",
-                n=10,
-                seed=42,
-                return_dist=True,
-                delta_weights=delta_weights,
+                percentiles=ds.percentile,
             )
             np.testing.assert_array_almost_equal(
-                out[0].QMOYAN.isel(station=0).values, [2.1, 7.5, 12.0, 12.0, 14.865]
+                out[1].QMOYAN.isel(station=0).values, [2.1, 7.5, 12.0, 12.0, 14.865]
             )
-            assert sum(out[2].QMOYAN.isel(station=0).values == 5) < sum(
-                out[2].QMOYAN.isel(station=0).values == 50
+            assert sum(deltas_dist.QMOYAN.isel(station=0).values == 5) < sum(
+                deltas_dist.QMOYAN.isel(station=0).values == 50
             )  # 50 should be sampled more often
         elif weights == "both":
+            ds_dist = xh.cc.weighted_random_sampling(
+                ds, weights=ds_weights, n=10, seed=42
+            )
+            deltas_dist = xh.cc.weighted_random_sampling(
+                deltas, weights=delta_weights, n=10, seed=42
+            )
             out = xh.cc.sampled_indicators(
-                ds,
-                deltas,
+                ds_dist,
+                deltas_dist,
                 delta_kind="percentage",
-                n=10,
-                seed=42,
-                return_dist=True,
-                ds_weights=ds_weights,
-                delta_weights=delta_weights,
+                percentiles=ds.percentile,
             )
             np.testing.assert_array_almost_equal(
-                out[0].QMOYAN.isel(station=0).values, [6.3, 12.0, 13.5, 13.5, 14.865]
+                out[1].QMOYAN.isel(station=0).values, [6.3, 12.0, 13.5, 13.5, 14.865]
             )
         else:
             raise ValueError(f"Unknown value for 'weights': {weights}")
 
         assert all(
             chosen in expected_out1
-            for chosen in np.unique(out[1].QMOYAN.isel(station=0).values)
+            for chosen in np.unique(ds_dist.QMOYAN.isel(station=0).values)
         )
         assert all(
             chosen in expected_out2
-            for chosen in np.unique(out[2].QMOYAN.isel(station=0).values)
+            for chosen in np.unique(deltas_dist.QMOYAN.isel(station=0).values)
         )
         assert all(
-            "station" in o.dims for o in out
+            "station" in o.dims for o in list(out) + [ds_dist, deltas_dist]
         )  # "station" is a shared dimension, so it should be in all outputs
 
     def test_weighted_time(self):
@@ -348,18 +388,18 @@ class TestSampledIndicators:
             },
         )
 
+        ds_dist = xh.cc.weighted_random_sampling(ds, weights=ds_weights, n=10, seed=42)
+        deltas_dist = xh.cc.weighted_random_sampling(
+            deltas, weights=delta_weights, n=10, seed=42, include_dims=["realization"]
+        )
         out = xh.cc.sampled_indicators(
-            ds,
-            deltas,
+            ds_dist,
+            deltas_dist,
             delta_kind="absolute",
-            n=10,
-            seed=42,
-            return_dist=True,
-            ds_weights=ds_weights,
-            delta_weights=delta_weights,
+            percentiles=ds.percentile,
         )
         np.testing.assert_array_almost_equal(
-            out[0].QMOYAN.isel(station=0, time=0).values,
+            out[1].QMOYAN.isel(station=0, time=0).values,
             [
                 11.0,
                 13.0,
@@ -369,7 +409,7 @@ class TestSampledIndicators:
             ],  # Roughly ds.QMOYAN.isel(station=0, foo=1).values + 5
         )
         np.testing.assert_array_almost_equal(
-            out[0].QMOYAN.isel(station=0, time=1).values,
+            out[1].QMOYAN.isel(station=0, time=1).values,
             [
                 51.0,
                 53.0,
@@ -380,22 +420,30 @@ class TestSampledIndicators:
         )
 
         assert all(
-            "station" in o.dims for o in out
+            "station" in o.dims for o in list(out) + [ds_dist, deltas_dist]
         )  # "station" is a shared dimension, so it should be in all outputs
         assert all(
-            "time" in o.dims for o in [out[0], out[2], out[3]]
+            "time" in o.dims for o in [out[1], deltas_dist, out[0]]
         )  # Time dimension should never be removed
 
         # Check a few attributes
-        assert all(o.QMOYAN.attrs["sampling_kind"] == "absolute" for o in out)
-        assert all(o.QMOYAN.attrs["sampling_n"] == 10 for o in out)
-        assert all(o.QMOYAN.attrs["sampling_seed"] == 42 for o in out)
-        assert out[0].QMOYAN.attrs["long_name"] == "Future percentiles of QMOYAN"
-        assert out[1].QMOYAN.attrs["long_name"] == "Historical distribution of QMOYAN"
-        assert out[2].QMOYAN.attrs["long_name"] == "Future delta distribution of QMOYAN"
-        assert out[3].QMOYAN.attrs["long_name"] == "Future distribution of QMOYAN"
-        assert all(o.QMOYAN.attrs["units"] == "m3/s" for o in [out[0], out[1], out[3]])
-        assert out[2].QMOYAN.attrs["units"] == "%"
+        assert all(o.QMOYAN.attrs["delta_kind"] == "absolute" for o in out)
+        assert all(
+            o.QMOYAN.attrs["sampling_n"] == 10
+            for o in list(out) + [ds_dist, deltas_dist]
+        )
+        assert all(
+            o.QMOYAN.attrs["sampling_seed"] == 42
+            for o in list(out) + [ds_dist, deltas_dist]
+        )
+        assert out[1].QMOYAN.attrs["long_name"] == "Reconstructed percentiles of QMOYAN"
+        assert ds_dist.QMOYAN.attrs["long_name"] == "Sampled distribution of QMOYAN"
+        assert deltas_dist.QMOYAN.attrs["long_name"] == "Sampled distribution of QMOYAN"
+        assert (
+            out[0].QMOYAN.attrs["long_name"] == "Reconstructed distribution of QMOYAN"
+        )
+        assert all(o.QMOYAN.attrs["units"] == "m3/s" for o in [out[1], ds_dist, out[0]])
+        assert deltas_dist.QMOYAN.attrs["units"] == "%"
 
     def test_sampled_indicators_weight_err(self):
         ds = xr.DataArray(
@@ -435,19 +483,6 @@ class TestSampledIndicators:
             },
         )
 
-        with pytest.raises(
-            ValueError,
-            match="is shared between 'ds' and 'deltas', but not between 'ds_weights' and 'delta_weights'.",
-        ):
-            xh.cc.sampled_indicators(
-                ds,
-                deltas,
-                delta_kind="percentage",
-                n=10,
-                seed=42,
-                delta_weights=delta_weights,
-            )
-
         deltas = deltas.rename({"platform": "time", "station": "horizon"})
         delta_weights = delta_weights.rename(
             {"platform": "time", "realization": "horizon"}
@@ -456,7 +491,13 @@ class TestSampledIndicators:
             NotImplementedError,
             match="Weights on multiple time dimensions are not supported.",
         ):
-            xh.cc._weighted_sampling(deltas, delta_weights, n=10, seed=42)
+            xh.cc.weighted_random_sampling(
+                deltas,
+                weights=delta_weights,
+                n=10,
+                seed=42,
+                include_dims=["realization"],
+            )
 
     def test_p_weights(self):
         def _make_da(arr):
@@ -501,22 +542,8 @@ class TestSampledIndicators:
         assert set(out.dims) == set(
             ["station", "sample"] + (["platform"] if weights_ndim == 1 else [])
         )
-        assert list(out["sample"].coords) == ["sample", "percentile"] + (
-            ["platform"] if weights_ndim == 2 else []
-        )
+        assert list(out["sample"].coords) == ["sample"]
         assert len(out["sample"]) == 10
-
-        np.testing.assert_array_equal(
-            out["percentile"],
-            {
-                1: [50, 50, 75, 50, 25, 75, 50, 75, 50, 50],
-                2: [25, 25, 50, 25, 25, 75, 25, 25, 25, 25],
-            }[weights_ndim],
-        )  # With seed=42
-        if weights_ndim == 2:
-            np.testing.assert_array_equal(
-                out["platform"], ["y", "x", "y", "x", "x", "y", "x", "y", "x", "x"]
-            )
 
     def test_weighted_sampling_errors(self):
         ds = xr.DataArray(


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [ ] CHANGELOG.rst has been updated (with summary of main changes).
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Turns out that `sampled_indicators` was too memory-inefficient for bigger applications and could quickly grow to 10s or even 100s of Gb of RAM. Thus, the function has been split in two to allow for writing the results of the sampling on disk and offload some of the RAM usage. No miracle can be done, but this should be slightly better.
* `_weighted_sampling` was almost completely rewritten to hopefully make better use of chunks and multithreading through `dask`.

### Does this PR introduce a breaking change?

- Yes. While this does not affect the numerical results themselves, this is an almost complete refactoring of `sampled_indicators`, from the inputs required to the outputs produced.


### Other information:
