### PR TITLE
Skip notebook execution during translation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,7 +34,7 @@ Breaking changes
 
 Internal changes
 ^^^^^^^^^^^^^^^^
-* Running the translation no longer executes the notebooks. (:pull:`330`).
+* Running the docs translation steps from Makefile or Batchfile no longer executes the notebooks. (:pull:`330`).
 
 v0.5.0 (2025-04-24)
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,10 @@ Breaking changes
 * The variables `t` from `xhfa.local.parametric_quantiles`, `rp` from `xhfa.regional.calculate_rp_from_afr` and `return_periods` from `xhfa.uncertainties.calc_q_iter` all renamed `return_period`. (:issue:`269`, :pull:`317`).
 * The function `xhfa.regional.calculate_rp_from_afr` was renamed `xhfa.regional.calculate_return_period_from_afr`. (:pull:`317`).
 
+Internal changes
+^^^^^^^^^^^^^^^^
+* Running the translation no longer executes the notebooks. (:pull:`330`).
+
 v0.5.0 (2025-04-24)
 -------------------
 Contributors to this version: Thomas-Charles Fortier Filion (:user:`TC-FF`), Gabriel Rondeau-Genesse (:user:`RondeauG`), Trevor James Smith (:user:`Zeitsperre`), Julián Ospina (:user:`ospinajulian`), Essi Parent (:user:`essicolo`).

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ autodoc: clean-docs ## create sphinx-apidoc files:
 	sphinx-apidoc -o docs/apidoc --private --module-first src/xhydro
 
 initialize-translations: clean-docs autodoc ## initialize translations, including autodoc-generated files (but not the API docs)
-	${MAKE} -C docs gettext
+	env SKIP_NOTEBOOKS=1 ${MAKE} -C docs gettext
 	sphinx-intl update -p docs/_build/gettext -d docs/locales -l fr
 	rm -fr docs/locales/fr/LC_MESSAGES/apidoc
 

--- a/make-translations.bat
+++ b/make-translations.bat
@@ -4,6 +4,9 @@ rem Batch script to handle translation work
 rem Remove French locale .mo files
 del /q docs\locales\fr\LC_MESSAGES\*.mo
 
+rem Temporarily set the environment variable to skip notebooks
+set SKIP_NOTEBOOKS=1
+
 rem Generate gettext files
 sphinx-build -b gettext docs docs\_build\gettext
 

--- a/make-translations.bat
+++ b/make-translations.bat
@@ -2,7 +2,7 @@
 rem Batch script to handle translation work
 
 rem Remove French locale .mo files
-del /q docs\locales\fr\LC_MESSAGES\*.mo
+del /s /q docs\locales\fr\LC_MESSAGES\*.mo
 
 rem Temporarily set the environment variable to skip notebooks
 set SKIP_NOTEBOOKS=1


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
  - [ ] If changes affect the GIS, Raven Modelling, Extremes.jl or Use Case Example notebooks, they have been re-run (ReadTheDocs will not update these).
  - [ ] If text has changed, ``make initialize-translations`` / ``make-translations.bat`` has been run and translations have been updated.
- [ ] (If applicable) Tests have been added.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Since we don't translate the outputs, we don't actually need to run the notebooks.

### Does this PR introduce a breaking change?


### Other information:
