### PR TITLE
Fix problem with tox py312

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+v0.7.0 (Unreleased)
+-------------------
+Contributors to this version: Gabriel Rondeau-Genesse (:user:`RondeauG`).
+
+Bug fixes
+^^^^^^^^^
+* Fixed a compatibility issue with `xarray >=2025.9.1`` in `xhfa.regional.fit_pca`. (:pull:`355`).
+
 v0.6.0 (2025-09-22)
 -------------------
 Contributors to this version: Louise Arnal (:user:`lou-a`), Thomas-Charles Fortier Filion (:user:`TC-FF`), Gabriel Rondeau-Genesse (:user:`RondeauG`), Julián Ospina (:user:`ospinajulian`).

--- a/src/xhydro/frequency_analysis/regional.py
+++ b/src/xhydro/frequency_analysis/regional.py
@@ -171,7 +171,7 @@ def fit_pca(ds: xr.Dataset, **kwargs) -> tuple:
     """
     ds = _scale_data(ds)
     df = ds.to_dataframe()
-    # Prevent a bug with pip environments where `to_dataframe` does not add the MultiIndex as data columns
+    # PCA needs the MultiIndex to be included in the dataframe columns, which is no longer the case with xarray >=2025.9.1
     if not all(c in df.columns for c in df.index.names):
         df_tmp = df.reset_index()
         df_tmp.index = df.index


### PR DESCRIPTION
### What kind of change does this PR introduce?

* Fixes the issue with the PCA test in tox-Python3.12

### Other information:

In other environments, `ds.to_dataframe()` produces:
```
              time  Station      data
time Station                         
0    0           0        0  0.796788
     1           0        1 -0.555955
     2           0        2  0.767213
     3           0        3  0.408236
     4           0        4  1.314047
...            ...      ...       ...
99   0          99        0 -1.537546
     1          99        1  1.017109
     2          99        2 -1.366089
     3          99        3  0.782118
     4          99        4  1.733661
```

Currently, if installing `xHydro` with `pip install` and Python 3.12, it gives:
```
                  data
time Station          
0    0        0.817340
     1        0.923166
     2       -0.911894
     3        0.533638
     4        0.767992
...                ...
99   0       -1.680657
     1       -1.444676
     2       -1.752213
     3        0.590432
     4       -1.312699
```

My fix makes sure that the dataframe has the expected form.