### PR TITLE
Pin broken pandas version

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -13,7 +13,7 @@ dependencies:
   - matplotlib-base
   - numpy >=1.25
   - odc-stac
-  - pandas >=2.2
+  - pandas >=2.2, !=3.0.4  # FIXME: 3.0.4 causes segfaults. https://github.com/pandas-dev/pandas/issues/66086
   - planetary-computer
   - pooch >=1.8.0
   - pystac >=1.12.0

--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - matplotlib-base
   - numpy >=1.25
   - odc-stac
-  - pandas >=2.2
+  - pandas >=2.2, !=3.0.4  # FIXME: 3.0.4 causes segfaults. https://github.com/pandas-dev/pandas/issues/66086
   - planetary-computer
   - pooch >=1.8.0
   - pystac >=1.12.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ dependencies = [
   "matplotlib",
   "numpy >=1.25",
   "odc-stac",
-  "pandas >=2.2",
+  "pandas >=2.2, !=3.0.4", # FIXME: 3.0.4 causes segfaults. https://github.com/pandas-dev/pandas/issues/66086
   "planetary-computer",
   "pooch >=1.8.0",
   "pystac >=1.12.0",


### PR DESCRIPTION
### What kind of change does this PR introduce?

* Prevents `pandas v3.0.4` from being used, since it causes segfaults in our CI workflows.

### Other information:
https://github.com/pandas-dev/pandas/issues/66086
